### PR TITLE
Switch to react-native-mymonero-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implements Monero send/receive functionality per the spec for crypto currency pl
 
 ## Installing
 
-    npm i edge-currency-monero -s
+    yarn add edge-currency-monero react-native-mymonero-core
 
 ```
 import { moneroCurrencyPluginFactory } from `edge-currency-monero`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "contributors": [
     "Paul Puey <paul@edge.app>"
   ],
+  "main": "./index.js",
+  "module": "./lib/xmrIndex.js",
   "files": [
     "CHANGELOG.md",
     "index.js",
@@ -20,8 +22,6 @@
     "package.json",
     "README.md"
   ],
-  "main": "./index.js",
-  "module": "./lib/xmrIndex.js",
   "scripts": {
     "build": "rimraf lib && sucrase ./src -q -d ./lib -t flow && webpack",
     "fix": "npm run lint -- --fix",
@@ -76,6 +76,9 @@
     "sucrase": "^3.9.5",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3"
+  },
+  "peerDependencies": {
+    "react-native-mymonero-core": "^0.1.0"
   },
   "react-native": "./lib/xmrIndex.js"
 }

--- a/src/react-native-io.js
+++ b/src/react-native-io.js
@@ -1,12 +1,5 @@
-// TODO: import { moneroCore } from 'react-native-fast-crypto'
-import 'react-native-fast-crypto'
+import { callMyMonero } from 'react-native-mymonero-core'
 
 export default function makeCustomIo() {
-  if (global.moneroCore == null) {
-    throw new Error(
-      'Please install & link https://github.com/EdgeApp/mymonero-core-js'
-    )
-  }
-  const { methodByString } = global.moneroCore
-  return { methodByString }
+  return { callMyMonero }
 }

--- a/src/xmrPlugin.js
+++ b/src/xmrPlugin.js
@@ -227,8 +227,8 @@ export function makeMoneroPlugin(
   const { io, nativeIo, initOptions = { apiKey: '' } } = opts
 
   if (nativeIo['edge-currency-monero']) {
-    const { methodByString } = nativeIo['edge-currency-monero']
-    global.moneroCore = { methodByString }
+    const { callMyMonero } = nativeIo['edge-currency-monero']
+    global.moneroCore = { methodByString: callMyMonero }
   }
 
   let toolsPromise: Promise<EdgeCurrencyTools>


### PR DESCRIPTION
Until now, the GUI has been using the global object to feed in the react-native-mymonero-core methods. This repo should really be grabbing those on its own.

I believe this will be a breaking change, so we may want to be picky about how we merge this.