### PR TITLE
William/fix send crash

### DIFF
--- a/src/MyMoneroApi.js
+++ b/src/MyMoneroApi.js
@@ -10,7 +10,6 @@ import type {
   Priority,
   SeedAndKeys
 } from 'react-native-mymonero-core'
-import { bridgifyObject, close } from 'yaob'
 
 const parserUtils = require('./mymonero-utils/ResponseParser.js')
 
@@ -224,7 +223,7 @@ export class MyMoneroApi {
     }
 
     // Make the transaction:
-    const args = bridgifyObject({
+    return await this.cppBridge.createTransaction({
       destinations: [
         {
           send_amount: amount,
@@ -241,11 +240,6 @@ export class MyMoneroApi {
       unspentOuts,
       randomOutsCb
     })
-    try {
-      return await this.cppBridge.createTransaction(args)
-    } finally {
-      close(args)
-    }
   }
 
   async broadcastTransaction(tx: string): Promise<void> {

--- a/src/react-native-io.js
+++ b/src/react-native-io.js
@@ -1,7 +1,7 @@
-// @flow
+import bridge from 'react-native-mymonero-core'
 
-import bridge, { type CppBridge } from 'react-native-mymonero-core'
-
-export default function makeCustomIo(): CppBridge {
-  return bridge
+export default function makeCustomIo() {
+  // Send across the raw C++ API,
+  // since that does not need callbacks:
+  return bridge.Module
 }

--- a/src/xmrPlugin.js
+++ b/src/xmrPlugin.js
@@ -210,18 +210,14 @@ export function makeMoneroPlugin(
   opts: EdgeCorePluginOptions
 ): EdgeCurrencyPlugin {
   const { io, nativeIo, initOptions = { apiKey: '' } } = opts
-  const cppBridge: CppBridge = nativeIo['edge-currency-monero']
 
-  const options = {
-    appUserAgentProduct: 'tester',
-    appUserAgentVersion: '0.0.1',
+  const cppBridge: CppBridge = nativeIo['edge-currency-monero']
+  const myMoneroApi = new MyMoneroApi(cppBridge, {
     apiKey: initOptions.apiKey,
     apiServer: 'https://edge.mymonero.com:8443',
     fetch: io.fetch,
-    randomBytes: io.random,
     nettype: 'MAINNET'
-  }
-  const myMoneroApi = new MyMoneroApi(cppBridge, options)
+  })
 
   let toolsPromise: Promise<EdgeCurrencyTools>
   function makeCurrencyTools(): Promise<EdgeCurrencyTools> {

--- a/src/xmrPlugin.js
+++ b/src/xmrPlugin.js
@@ -16,7 +16,7 @@ import {
   type EdgeParsedUri,
   type EdgeWalletInfo
 } from 'edge-core-js/types'
-import type { CppBridge } from 'react-native-mymonero-core'
+import CppBridge from 'react-native-mymonero-core/src/CppBridge.js'
 import { parse, serialize } from 'uri-js'
 
 import { MyMoneroApi } from './MyMoneroApi.js'
@@ -211,7 +211,9 @@ export function makeMoneroPlugin(
 ): EdgeCurrencyPlugin {
   const { io, nativeIo, initOptions = { apiKey: '' } } = opts
 
-  const cppBridge: CppBridge = nativeIo['edge-currency-monero']
+  // Grab the raw C++ API and wrap it in argument parsing:
+  const cppModule = nativeIo['edge-currency-monero']
+  const cppBridge = new CppBridge(cppModule)
   const myMoneroApi = new MyMoneroApi(cppBridge, {
     apiKey: initOptions.apiKey,
     apiServer: 'https://edge.mymonero.com:8443',

--- a/test/nodeNativeIo.js
+++ b/test/nodeNativeIo.js
@@ -13,7 +13,7 @@ const bridge: any = {}
 for (const method of [
   'addressAndKeysFromSeed',
   'compareMnemonics',
-  'createTransaction',
+  'createAndSignTx',
   'decodeAddress',
   'estimateTxFee',
   'generateKeyImage',
@@ -24,11 +24,12 @@ for (const method of [
   'isValidKeys',
   'mnemonicFromSeed',
   'newIntegratedAddress',
+  'prepareTx',
   'seedAndKeysFromMnemonic'
 ]) {
   bridge[method] = async function (...args) {
     const bridge = await bridgePromise
-    return bridge[method](...args)
+    return bridge.Module[method](...args)
   }
 }
 


### PR DESCRIPTION
The `bridgifyObject` call is not working correctly, since we are using a different YAOB instance than the core.

Instead of dealing with this, we we send across the raw C++ API. Then we hijack the CppBridge object and instantiate it on the WebView side, using the C++ API we passed earlier. Yes, this is a hack, but it came out pretty cleanly.