### PR TITLE
Remove onBalanceChanged from doInitialCallbacks()

### DIFF
--- a/src/xmrEngine.js
+++ b/src/xmrEngine.js
@@ -383,9 +383,6 @@ export class MoneroEngine {
   doInitialCallbacks() {
     for (const currencyCode of this.walletLocalData.enabledTokens) {
       try {
-        this.edgeTxLibCallbacks.onTransactionsChanged(
-          this.walletLocalData.transactionsObj[currencyCode]
-        )
         this.edgeTxLibCallbacks.onBalanceChanged(
           currencyCode,
           this.walletLocalData.totalBalances[currencyCode]


### PR DESCRIPTION
Remove onBalanceChanged from doInitialCallbacks()

#### Merge note
-fix: Monero wallet initialization performance improvement

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202001035553600