### PR TITLE
Add support for custom nodes

### DIFF
--- a/src/MyMoneroApi.js
+++ b/src/MyMoneroApi.js
@@ -94,6 +94,11 @@ export class MyMoneroApi {
     this.keyImageCache = {}
   }
 
+  changeServer(apiUrl: string, apiKey: string) {
+    this.apiKey = apiKey
+    this.apiUrl = apiUrl
+  }
+
   /**
    * Authenticates with the MyMonero light-wallet server.
    */

--- a/src/MyMoneroApi.js
+++ b/src/MyMoneroApi.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {
+  type Cleaner,
   asArray,
   asBoolean,
   asNumber,
@@ -50,9 +51,14 @@ export type CreateTransactionOptions = {
   targetAddress: string
 }
 
+const asNumberBoolean: Cleaner<boolean> = raw => {
+  if (typeof raw === 'number') return Boolean(raw)
+  return asBoolean(raw)
+}
+
 const asLoginResult = asObject({
-  generated_locally: asOptional(asBoolean), // Flag from initial account creation
-  new_address: asBoolean, // Whether account was just created
+  generated_locally: asOptional(asNumberBoolean), // Flag from initial account creation
+  new_address: asNumberBoolean, // Whether account was just created
   start_height: asOptional(asNumber), // Account scanning start block
   view_key: asOptional(asString) // View key bytes
 })
@@ -108,6 +114,7 @@ export class MyMoneroApi {
       address: address,
       api_key: this.apiKey,
       create_account: true,
+      generated_locally: true,
       view_key: privateViewKey
     })
 
@@ -131,11 +138,11 @@ export class MyMoneroApi {
       transaction_height: asOptional(asNumber),
       transactions: asArray(
         asObject({
-          coinbase: asBoolean, // True if tx is coinbase
+          coinbase: asNumberBoolean, // True if tx is coinbase
           hash: asString, // Bytes of tx hash
           height: asNumber, // Block height
           id: asNumber, // Index of tx in blockchain
-          mempool: asBoolean, // True if tx is in mempool
+          mempool: asNumberBoolean, // True if tx is in mempool
           mixin: asNumber, // Mixin of the receive
           payment_id: asOptional(asString), // Bytes of tx payment id
           spent_outputs: asOptional(asArray(asSpentOutput)), // List of possible spends
@@ -170,7 +177,7 @@ export class MyMoneroApi {
     const asAddressInfo = asObject({
       blockchain_height: asNumber, // Current blockchain height
       locked_funds: asString, // Sum of unspendable XMR
-      rates: asObject(asNumber), // Rates
+      rates: asOptional(asObject(asNumber)), // Rates
       scanned_block_height: asNumber, // Current scan progress
       scanned_height: asNumber, // Current tx scan progress
       spent_outputs: asOptional(asArray(asSpentOutput)), // Possible spend info

--- a/src/moneroInfo.js
+++ b/src/moneroInfo.js
@@ -28,7 +28,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
     {
       name: 'XMR',
       multiplier: '1000000000000',
-      symbol: '‎ɱ'
+      symbol: 'ɱ'
     }
   ],
   metaTokens: [],

--- a/src/moneroInfo.js
+++ b/src/moneroInfo.js
@@ -2,14 +2,11 @@
 
 import { type EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import type { MoneroSettings } from './moneroTypes.js'
+import type { MoneroUserSettings } from './moneroTypes.js'
 
-const otherSettings: MoneroSettings = {
-  mymoneroApiServers: ['https://edge.mymonero.com:8443']
-}
-
-const defaultSettings: any = {
-  otherSettings
+const defaultSettings: MoneroUserSettings = {
+  enableCustomServers: false,
+  moneroLightwalletServer: 'https://edge.mymonero.com:8443'
 }
 
 export const currencyInfo: EdgeCurrencyInfo = {

--- a/src/moneroTypes.js
+++ b/src/moneroTypes.js
@@ -3,7 +3,7 @@
  */
 // @flow
 
-import { asObject, asOptional, asString } from 'cleaners'
+import { asBoolean, asMaybe, asObject, asOptional, asString } from 'cleaners'
 import { type EdgeCurrencyTools, type EdgeWalletInfo } from 'edge-core-js'
 import { type Nettype } from 'react-native-mymonero-core'
 
@@ -16,9 +16,11 @@ export type MoneroNetworkInfo = {
   nettype: Nettype
 }
 
-export type MoneroSettings = {
-  mymoneroApiServers: string[]
-}
+export const asMoneroUserSettings = asObject({
+  enableCustomServers: asMaybe(asBoolean, false),
+  moneroLightwalletServer: asMaybe(asString)
+})
+export type MoneroUserSettings = $Call<typeof asMoneroUserSettings>
 
 export const asPrivateKeys = asObject({
   moneroKey: asString,


### PR DESCRIPTION
### CHANGELOG

- added: Allow setting custom nodes via the `userSettings` option.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

I have temporarily started an `http://monero-lws.edge.app` server. I can add accounts via the command line if you would like to test, or I can do a barcode login to pass over my own personal test account. I can confirm that the test server receives network traffic from the Edge app when this setting is enabled.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204583307528860
  - https://app.asana.com/0/0/1205254896724399