### PR TITLE
Support Monero URI formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- fixed: URI parsing and creation according to the correct format
+
 # 1.3.1 (2024-03-21)
 
 - fixed: Include missing files in the NPM package.

--- a/src/MoneroTools.ts
+++ b/src/MoneroTools.ts
@@ -115,7 +115,10 @@ export class MoneroTools {
       throw new Error('InvalidPublicAddressError')
     }
 
-    const amountStr = getParameterByName('amount', uri)
+    // Prioritize the correct Monero URI format, while falling back to BIP21
+    // formats.
+    const amountStr =
+      getParameterByName('tx_amount', uri) ?? getParameterByName('amount', uri)
     if (amountStr != null) {
       const denom = getDenomInfo('XMR')
       if (denom == null) {
@@ -126,8 +129,12 @@ export class MoneroTools {
       currencyCode = 'XMR'
     }
     const uniqueIdentifier = getParameterByName('tx_payment_id', uri)
-    const label = getParameterByName('label', uri)
-    const message = getParameterByName('message', uri)
+    const label =
+      getParameterByName('recipient_name', uri) ??
+      getParameterByName('label', uri)
+    const message =
+      getParameterByName('tx_description', uri) ??
+      getParameterByName('message', uri)
     const category = getParameterByName('category', uri)
 
     const edgeParsedUri: EdgeParsedUri = {
@@ -184,13 +191,13 @@ export class MoneroTools {
         }
         const amount = div(nativeAmount, denom.multiplier, 12)
 
-        queryString += 'amount=' + amount + '&'
+        queryString += 'tx_amount=' + amount + '&'
       }
       if (typeof obj.label === 'string') {
-        queryString += 'label=' + obj.label + '&'
+        queryString += 'recipient_name=' + obj.label + '&'
       }
       if (typeof obj.message === 'string') {
-        queryString += 'message=' + obj.message + '&'
+        queryString += 'tx_description=' + obj.message + '&'
       }
       queryString = queryString.substr(0, queryString.length - 1)
 

--- a/test/plugin/fixtures.json
+++ b/test/plugin/fixtures.json
@@ -18,12 +18,19 @@
       "address only": ["42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt"],
       "invalid address": ["42kFgCShemF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJlSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaK", "0x42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaK"],
       "uri address": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt"],
-      "uri address with amount": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=12345.6789", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "12345678900000000", "XMR"],
+      "(BIP21) uri address with amount": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=12345.6789", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "12345678900000000", "XMR"],
+      "(BIP21) uri address with unique identifier": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_payment_id=helloworldhowdoyoudo1234", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "helloworldhowdoyoudo1234", "XMR"],
+      "(BIP21) uri address with unique identifier and without network prefix": ["42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_payment_id=helloworldhowdoyoudo1234", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "helloworldhowdoyoudo1234", "XMR"],
+      "(BIP21) uri address with amount & label": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=1234.56789&label=Johnny%20Monero", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero"],
+      "(BIP21) uri address with amount, label & message": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=1234.56789&label=Johnny%20Monero&message=Hello%20World,%20I%20miss%20you%20!", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero", "Hello World, I miss you !"],
+      "(BIP21) uri address with unsupported param": ["monero:0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6?unsupported=helloworld&amount=12345.6789", "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6", "12345678900000000", "XMR"],
+      
+      "uri address with amount": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=12345.6789", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "12345678900000000", "XMR"],
       "uri address with unique identifier": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_payment_id=helloworldhowdoyoudo1234", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "helloworldhowdoyoudo1234", "XMR"],
       "uri address with unique identifier and without network prefix": ["42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_payment_id=helloworldhowdoyoudo1234", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "helloworldhowdoyoudo1234", "XMR"],
-      "uri address with amount & label": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=1234.56789&label=Johnny%20Monero", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero"],
-      "uri address with amount, label & message": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=1234.56789&label=Johnny%20Monero&message=Hello%20World,%20I%20miss%20you%20!", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero", "Hello World, I miss you !"],
-      "uri address with unsupported param": ["monero:0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6?unsupported=helloworld&amount=12345.6789", "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6", "12345678900000000", "XMR"]
+      "uri address with amount & label": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=1234.56789&recipient_name=Johnny%20Monero", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero"],
+      "uri address with amount, label & message": ["monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=1234.56789&recipient_name=Johnny%20Monero&tx_description=Hello%20World,%20I%20miss%20you%20!", "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt", "1234567890000000", "XMR", "Johnny Monero", "Hello World, I miss you !"],
+      "uri address with unsupported param": ["monero:0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6?unsupported=helloworld&tx_amount=12345.6789", "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6", "12345678900000000", "XMR"]
     },
     "encodeUri": {
       "address only": [{"publicAddress": "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt"}, "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt"],
@@ -31,20 +38,20 @@
       "address & amount": [{
         "publicAddress": "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt",
         "nativeAmount": "123456780000"
-      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=0.12345678"],
+      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=0.12345678"],
       "address, amount, and label": [{
         "publicAddress": "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt",
         "nativeAmount": "123456780000",
         "currencyCode": "XMR",
         "label": "Johnny Monero"
-      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=0.12345678&label=Johnny%20Monero"],
+      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=0.12345678&recipient_name=Johnny%20Monero"],
       "address, amount, label, & message": [{
         "publicAddress": "42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt",
         "nativeAmount": "123456780000",
         "currencyCode": "XMR",
         "label": "Johnny Monero",
         "message": "Hello World, I miss you !"
-      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?amount=0.12345678&label=Johnny%20Monero&message=Hello%20World,%20I%20miss%20you%20!"],
+      }, "monero:42kFgCShfmF3g9ASassxoZU3mTzUznUiBEStZxsKnocbJAHPQBmJJjSHPYV4oqwJgx6ce9cFXWtDVXD6Dwqhr6eYJovjaKt?tx_amount=0.12345678&recipient_name=Johnny%20Monero&tx_description=Hello%20World,%20I%20miss%20you%20!"],
       "invalid currencyCode": [{
         "publicAddress": "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6",
         "nativeAmount": "123456780000",

--- a/test/plugin/plugin.ts
+++ b/test/plugin/plugin.ts
@@ -162,114 +162,114 @@ for (const fixture of fixtures) {
       assert.equal(parsedUri.nativeAmount, undefined)
       assert.equal(parsedUri.currencyCode, undefined)
     })
-    it('uri address with amount', async function () {
+    it('(BIP21) uri address with amount', async function () {
       const parsedUri = await tools.parseUri(
-        fixture.parseUri['uri address with amount'][0]
+        fixture.parseUri['(BIP21) uri address with amount'][0]
       )
       assert.equal(
         parsedUri.publicAddress,
-        fixture.parseUri['uri address with amount'][1]
+        fixture.parseUri['(BIP21) uri address with amount'][1]
       )
       assert.equal(
         parsedUri.nativeAmount,
-        fixture.parseUri['uri address with amount'][2]
+        fixture.parseUri['(BIP21) uri address with amount'][2]
       )
       assert.equal(
         parsedUri.currencyCode,
-        fixture.parseUri['uri address with amount'][3]
+        fixture.parseUri['(BIP21) uri address with amount'][3]
       )
     })
-    it('uri address with unique identifier', async function () {
+    it('(BIP21) uri address with unique identifier', async function () {
       const parsedUri = await tools.parseUri(
-        fixture.parseUri['uri address with unique identifier'][0]
+        fixture.parseUri['(BIP21) uri address with unique identifier'][0]
       )
       assert.equal(
         parsedUri.publicAddress,
-        fixture.parseUri['uri address with unique identifier'][1]
+        fixture.parseUri['(BIP21) uri address with unique identifier'][1]
       )
       assert.equal(
         parsedUri.uniqueIdentifier,
-        fixture.parseUri['uri address with unique identifier'][2]
+        fixture.parseUri['(BIP21) uri address with unique identifier'][2]
       )
     })
-    it('uri address with unique identifier and without network prefix', async function () {
+    it('(BIP21) uri address with unique identifier and without network prefix', async function () {
       const parsedUri = await tools.parseUri(
         fixture.parseUri[
-          'uri address with unique identifier and without network prefix'
+          '(BIP21) uri address with unique identifier and without network prefix'
         ][0]
       )
       assert.equal(
         parsedUri.publicAddress,
         fixture.parseUri[
-          'uri address with unique identifier and without network prefix'
+          '(BIP21) uri address with unique identifier and without network prefix'
         ][1]
       )
       assert.equal(
         parsedUri.uniqueIdentifier,
         fixture.parseUri[
-          'uri address with unique identifier and without network prefix'
+          '(BIP21) uri address with unique identifier and without network prefix'
         ][2]
       )
     })
-    it('uri address with amount & label', async function () {
+    it('(BIP21) uri address with amount & label', async function () {
       const parsedUri = await tools.parseUri(
-        fixture.parseUri['uri address with amount & label'][0]
+        fixture.parseUri['(BIP21) uri address with amount & label'][0]
       )
       assert.equal(
         parsedUri.publicAddress,
-        fixture.parseUri['uri address with amount & label'][1]
+        fixture.parseUri['(BIP21) uri address with amount & label'][1]
       )
       assert.equal(
         parsedUri.nativeAmount,
-        fixture.parseUri['uri address with amount & label'][2]
+        fixture.parseUri['(BIP21) uri address with amount & label'][2]
       )
       assert.equal(
         parsedUri.currencyCode,
-        fixture.parseUri['uri address with amount & label'][3]
+        fixture.parseUri['(BIP21) uri address with amount & label'][3]
       )
       if (parsedUri.metadata == null) throw new Error('no metadata')
       assert.equal(
         parsedUri.metadata.name,
-        fixture.parseUri['uri address with amount & label'][4]
+        fixture.parseUri['(BIP21) uri address with amount & label'][4]
       )
     })
-    it('uri address with amount, label & message', async function () {
+    it('(BIP21) uri address with amount, label & message', async function () {
       const parsedUri: EdgeParsedUri = await tools.parseUri(
-        fixture.parseUri['uri address with amount & label'][0]
+        fixture.parseUri['(BIP21) uri address with amount & label'][0]
       )
       assert.equal(
         parsedUri.publicAddress,
-        fixture.parseUri['uri address with amount & label'][1]
+        fixture.parseUri['(BIP21) uri address with amount & label'][1]
       )
       assert.equal(
         parsedUri.nativeAmount,
-        fixture.parseUri['uri address with amount & label'][2]
+        fixture.parseUri['(BIP21) uri address with amount & label'][2]
       )
       assert.equal(
         parsedUri.currencyCode,
-        fixture.parseUri['uri address with amount & label'][3]
+        fixture.parseUri['(BIP21) uri address with amount & label'][3]
       )
       if (parsedUri.metadata == null) throw new Error('no metadata')
       assert.equal(
         parsedUri.metadata.name,
-        fixture.parseUri['uri address with amount & label'][4]
+        fixture.parseUri['(BIP21) uri address with amount & label'][4]
       )
     })
-    it('uri address with unsupported param', async function () {
+    it('(BIP21) uri address with unsupported param', async function () {
       const parsedUri = await tools.parseUri(
-        fixture.parseUri['uri address with amount & label'][0]
+        fixture.parseUri['(BIP21) uri address with amount & label'][0]
       )
       assert.equal(
         parsedUri.publicAddress,
-        fixture.parseUri['uri address with amount & label'][1]
+        fixture.parseUri['(BIP21) uri address with amount & label'][1]
       )
       assert.equal(
         parsedUri.nativeAmount,
-        fixture.parseUri['uri address with amount & label'][2]
+        fixture.parseUri['(BIP21) uri address with amount & label'][2]
       )
       assert.equal(
         parsedUri.currencyCode,
-        fixture.parseUri['uri address with amount & label'][3]
+        fixture.parseUri['(BIP21) uri address with amount & label'][3]
       )
     })
   })


### PR DESCRIPTION
- Do so while retaining support for parsing BIP21 URI formats.
- Update `encodeUri` to encode uris to the correct output string.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208782217930324