### PR TITLE
Fix `getFreshAddress` after creating a wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+- fixed: Fix `getFreshAddress` to return a non-empty `publicAddress` when calling immediately after creating a wallet.
 - fixed: Handle insufficient funds errors from native library into `InsufficientFundsError`.
 
 ## 1.5.0 (2025-04-21)


### PR DESCRIPTION
Fix `getFreshAddress` to return a non-empty `publicAddress` when calling immediately after creating a wallet

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210587047210433