### PR TITLE
Use Edge lws servers by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: *Breaking change* Change to use Edge LWS servers. Must specify edgeApiKey in plugin options, instead of apiKey
+
 ## 1.5.1 (2025-07-03)
 
 - fixed: Fix `getFreshAddress` to return a non-empty `publicAddress` when calling immediately after creating a wallet.

--- a/src/MoneroEngine.ts
+++ b/src/MoneroEngine.ts
@@ -97,7 +97,7 @@ export class MoneroEngine implements EdgeCurrencyEngine {
     const initOptions = asMoneroInitOptions(env.initOptions ?? {})
     const { networkInfo } = tools
 
-    this.apiKey = initOptions.apiKey
+    this.apiKey = initOptions.edgeApiKey
     this.io = env.io
     this.log = opts.log
     this.engineOn = false
@@ -110,7 +110,7 @@ export class MoneroEngine implements EdgeCurrencyEngine {
     this.currencyInfo = currencyInfo
     this.currencyTools = tools
     this.myMoneroApi = new MyMoneroApi(tools.cppBridge, {
-      apiKey: initOptions.apiKey,
+      apiKey: initOptions.edgeApiKey,
       apiServer: networkInfo.defaultServer,
       fetch: env.io.fetch,
       nettype: networkInfo.nettype
@@ -134,9 +134,6 @@ export class MoneroEngine implements EdgeCurrencyEngine {
       )
     }
 
-    // Hard coded for testing
-    // this.walletInfo.keys.moneroKey = '389b07b3466eed587d6bdae09a3613611de9add2635432d6cd1521af7bbc3757'
-    // this.walletInfo.keys.moneroAddress = '0x9fa817e5A48DD1adcA7BEc59aa6E3B1F5C4BeA9a'
     this.edgeTxLibCallbacks = callbacks
     this.walletLocalDisklet = walletLocalDisklet
 

--- a/src/MoneroTools.ts
+++ b/src/MoneroTools.ts
@@ -15,7 +15,7 @@ import type {
 import CppBridge from 'react-native-mymonero-core/src/CppBridge'
 import { parse, serialize } from 'uri-js'
 
-import { currencyInfo } from './moneroInfo'
+import { currencyInfo, MONERO_LWS_SERVER } from './moneroInfo'
 import type { MoneroNetworkInfo, PrivateKeys, PublicKeys } from './moneroTypes'
 
 function getDenomInfo(denom: string): EdgeDenomination | undefined {
@@ -37,7 +37,7 @@ export class MoneroTools {
   io: EdgeIo
   log: EdgeLog
   networkInfo: MoneroNetworkInfo = {
-    defaultServer: 'https://edge.mymonero.com:8443',
+    defaultServer: MONERO_LWS_SERVER,
     nettype: 'MAINNET'
   }
 

--- a/src/moneroInfo.ts
+++ b/src/moneroInfo.ts
@@ -2,9 +2,11 @@ import type { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import type { MoneroUserSettings } from './moneroTypes.js'
 
+export const MONERO_LWS_SERVER = 'https://monerolws1.edge.app'
+
 const defaultSettings: MoneroUserSettings = {
   enableCustomServers: false,
-  moneroLightwalletServer: 'https://edge.mymonero.com:8443'
+  moneroLightwalletServer: MONERO_LWS_SERVER
 }
 
 export const currencyInfo: EdgeCurrencyInfo = {

--- a/src/moneroTypes.ts
+++ b/src/moneroTypes.ts
@@ -16,7 +16,7 @@ import type { EdgeCurrencyTools, EdgeWalletInfo } from 'edge-core-js'
 import type { Nettype } from 'react-native-mymonero-core'
 
 export const asMoneroInitOptions = asObject({
-  apiKey: asOptional(asString, '')
+  edgeApiKey: asOptional(asString, '')
 })
 
 export interface MoneroNetworkInfo {


### PR DESCRIPTION
Breaking change. Must pass edgeApiKey into options instead of apiKey

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
