### PR TITLE
Add PocketChange feature for Monero wallet

### DIFF
--- a/src/MoneroLocalData.ts
+++ b/src/MoneroLocalData.ts
@@ -15,6 +15,8 @@ import {
 } from 'cleaners'
 import type { EdgeTokenId } from 'edge-core-js'
 
+import { asPocketChangeSetting } from './moneroTypes'
+
 export const DATA_STORE_FILE = 'txEngineFolder/walletLocalData.json'
 export const PRIMARY_CURRENCY_TOKEN_ID = null
 
@@ -68,7 +70,8 @@ export const asMoneroLocalData = asJSON(
     transactionsObj: asOptional(
       asMap(asEdgeToken, asArray(asNotNull)),
       () => new Map<EdgeTokenId, unknown[]>()
-    )
+    ),
+    pocketChangeSetting: asOptional(asPocketChangeSetting)
   })
 )
 

--- a/src/MoneroLocalData.ts
+++ b/src/MoneroLocalData.ts
@@ -15,7 +15,11 @@ import {
 } from 'cleaners'
 import type { EdgeTokenId } from 'edge-core-js'
 
-import { asPocketChangeSetting } from './moneroTypes'
+import {
+  asPocketChangeSetting,
+  asPocketSlot,
+  POCKET_SLOT_COUNT
+} from './moneroTypes'
 
 export const DATA_STORE_FILE = 'txEngineFolder/walletLocalData.json'
 export const PRIMARY_CURRENCY_TOKEN_ID = null
@@ -71,7 +75,13 @@ export const asMoneroLocalData = asJSON(
       asMap(asEdgeToken, asArray(asNotNull)),
       () => new Map<EdgeTokenId, unknown[]>()
     ),
-    pocketChangeSetting: asOptional(asPocketChangeSetting)
+    pocketChangeSetting: asOptional(asPocketChangeSetting),
+    pocketSlots: asOptional(asArray(asPocketSlot), () =>
+      Array.from({ length: POCKET_SLOT_COUNT }, () => ({
+        amount: '0',
+        txPubKey: ''
+      }))
+    )
   })
 )
 

--- a/src/moneroTypes.ts
+++ b/src/moneroTypes.ts
@@ -87,3 +87,19 @@ export const asSeenTxCheckpoint: Cleaner<number | undefined> = asCodec(
   v => (v == null ? undefined : v.toString())
 )
 export const wasSeenTxCheckpoint = uncleaner(asSeenTxCheckpoint)
+
+// PocketChange types
+export interface PocketChangeSetting {
+  enabled: boolean
+  amountPiconero: string  // Target amount per pocket in atomic units
+}
+
+export const asPocketChangeSetting = asObject({
+  enabled: asBoolean,
+  amountPiconero: asString
+})
+
+// PocketChange constants
+export const POCKET_AMOUNTS_XMR = [0.1, 0.2, 0.3, 0.5, 0.8, 1.3]
+export const POCKET_COUNT_MIN = 6
+export const POCKET_COUNT_MAX = 14

--- a/src/moneroTypes.ts
+++ b/src/moneroTypes.ts
@@ -89,17 +89,20 @@ export const asSeenTxCheckpoint: Cleaner<number | undefined> = asCodec(
 export const wasSeenTxCheckpoint = uncleaner(asSeenTxCheckpoint)
 
 // PocketChange types
-export interface PocketChangeSetting {
-  enabled: boolean
-  amountPiconero: string  // Target amount per pocket in atomic units
-}
-
 export const asPocketChangeSetting = asObject({
   enabled: asBoolean,
   amountPiconero: asString
 })
+export type PocketChangeSetting = ReturnType<typeof asPocketChangeSetting>
 
-// PocketChange constants
-export const POCKET_AMOUNTS_XMR = [0.1, 0.2, 0.3, 0.5, 0.8, 1.3]
-export const POCKET_COUNT_MIN = 6
-export const POCKET_COUNT_MAX = 14
+// PocketChange slot tracking: each slot represents a pocket output.
+// A slot is "funded" when txPubKey is non-empty, "empty" otherwise.
+export const asPocketSlot = asObject({
+  amount: asOptional(asString, '0'),
+  txPubKey: asOptional(asString, '')
+})
+export type PocketSlot = ReturnType<typeof asPocketSlot>
+
+export const POCKET_SLOT_COUNT = 14
+export const POCKET_SLOT_MIN = 6
+export const POCKET_SLOT_MAX = 14


### PR DESCRIPTION
## Overview

Implements PocketChange feature to solve Monero's 20-minute locked change UX problem. After sending Monero, change is locked for 10 blocks (~20 minutes), preventing immediate subsequent transactions. PocketChange automatically creates multiple change outputs ("pockets") during sends, ensuring users always have unlocked funds available.

## Changes

### Core Implementation

**`src/moneroTypes.ts`:**
- Add `PocketChangeSetting` interface (`enabled: boolean`, `amountPiconero: string`)
- Add pocket constants: `POCKET_AMOUNTS_XMR`, `POCKET_COUNT_MIN/MAX`

**`src/MoneroLocalData.ts`:**
- Extend `MoneroLocalData` to persist `pocketChangeSetting`
- Settings survive app restarts

**`src/MoneroEngine.ts`:**
- Implement `otherMethods.getPocketChangeTargetsForSpend(spendTargets)`
- Accepts user's spend targets, returns them with pocket targets appended
- Pocket targets marked with `otherParams: { isPocketChange: true }`
- Algorithm: Random 6-14 pockets, configurable amount per pocket
- Sends pocket change to wallet's main address (self-send)

### Algorithm Details

1. Calculate total spend amount from input targets
2. Calculate spendable balance: `total - locked - spend - fee buffer (10%)`
3. Generate random pocket count between 6-14
4. For each pocket: create target to wallet address with configured amount
5. Return: `[...original targets, ...pocket targets]`

### Design Decision: Main Address vs Subaddresses

Unlike Monerujo (uses Monero subaddresses indices 1-14), this implementation sends pocket change to the wallet's main address because:
- MyMonero-core-js doesn't expose subaddress derivation APIs
- Achieves same UX goal: separate UTXOs = unlocked funds available
- Simpler implementation, easier to maintain
- Trade-off: Slightly less privacy (address reuse)
- Future: Can add true subaddress support if needed

## Usage (GUI Integration)

```typescript
// Before makeSpend(), GUI calls:
const allTargets = await wallet.otherMethods.getPocketChangeTargetsForSpend([
  { publicAddress: recipientAddress, nativeAmount: sendAmount }
])

// Returns: [payment target, ...6-14 pocket targets]
// Pocket targets have: otherParams: { isPocketChange: true }

// GUI can show breakdown:
const paymentTargets = allTargets.filter(t => !t.otherParams?.isPocketChange)
const pocketTargets = allTargets.filter(t => t.otherParams?.isPocketChange)

// Then create spend with all targets:
const tx = await wallet.makeSpend({
  spendTargets: allTargets,
  ...otherSpendInfo
})
```

## Testing

Manual test procedure:
1. Enable PocketChange in wallet settings (0.1 XMR pocket amount)
2. Send Monero transaction
3. Verify transaction has multiple outputs (1 payment + ~6-14 pockets)
4. Immediately send again (should succeed using unlocked pocket funds)
5. Without PocketChange, step 4 would fail due to locked change

## Related

- GUI PR: (will be added as comment)
- Inspired by Monerujo: https://www.monerujo.app/pocketchange-explained.html
- Reference implementation: https://github.com/m2049r/xmrwallet

## Files Modified

- `src/moneroTypes.ts` - Types and constants
- `src/MoneroLocalData.ts` - Persistence layer
- `src/MoneroEngine.ts` - Core logic (+63 lines)

Total: ~82 lines added across 3 files

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213290072815004