### PR TITLE
Reduce UI lag: gate redundant Monero callbacks

### DIFF
--- a/src/MoneroEngine.ts
+++ b/src/MoneroEngine.ts
@@ -304,8 +304,10 @@ export class MoneroEngine implements EdgeCurrencyEngine {
     }
 
     this.saveTransactionState(PRIMARY_CURRENCY_TOKEN_ID, edgeTransaction)
-    this.edgeTxLibCallbacks.onTransactions(this.transactionEventArray)
-    this.transactionEventArray = []
+    if (this.transactionEventArray.length > 0) {
+      this.edgeTxLibCallbacks.onTransactions(this.transactionEventArray)
+      this.transactionEventArray = []
+    }
 
     return blockHeight
   }
@@ -457,10 +459,8 @@ export class MoneroEngine implements EdgeCurrencyEngine {
   doInitialCallbacks(): void {
     for (const tokenId of this.walletLocalData.enabledTokens) {
       try {
-        this.edgeTxLibCallbacks.onTokenBalanceChanged(
-          tokenId,
-          this.walletLocalData.totalBalances.get(tokenId) ?? '0'
-        )
+        const _bal = this.walletLocalData.totalBalances.get(tokenId) ?? '0'
+        this.edgeTxLibCallbacks.onTokenBalanceChanged(tokenId, _bal)
       } catch (e) {
         this.log.error('Error for currencyCode', tokenId, e)
       }

--- a/test/engine/engine.ts
+++ b/test/engine/engine.ts
@@ -73,7 +73,6 @@ for (const fixture of fixtures) {
     },
     onUnactivatedTokenIdsChanged() {},
     onStakingStatusChanged() {},
-    onSubscribeAddresses() {},
     onWcNewContractCall(payload) {
       emitter.emit('wcNewContractCall', payload)
     },


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Reduces RN JS thread starvation from Monero engine callbacks. Three fixes:

- **Remove stale `onSubscribeAddresses` from test mock**: Fixes a pre-existing TypeScript error in `test/engine/engine.ts` where the mock `EdgeCurrencyEngineCallbacks` still included a property removed from the type.
- **Gate empty transaction callbacks**: `onTransactions` is now only called when `transactionEventArray` is non-empty, preventing no-op bridge crossings on quiet blocks.
- **Gate `onSeenTxCheckpoint` + throttle `onAddressesChecked`**: `onSeenTxCheckpoint` is only emitted when the checkpoint value actually advances. `onAddressesChecked` is globally rate-limited to 1 emission per 500ms (sync-complete always passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior changes are limited to callback frequency/conditions (no transaction creation/broadcast logic changes), but could affect UI sync progress and downstream listeners that implicitly relied on extra emissions.
> 
> **Overview**
> Reduces React Native bridge/JS-thread pressure from Monero sync by **gating redundant engine callbacks**.
> 
> `MoneroEngine` now throttles `onAddressesChecked` progress emissions to at most once every 500ms (while still always emitting the final `1`), only calls `onTransactions` when there are actual transaction events to deliver, and only emits `onSeenTxCheckpoint` when the checkpoint value advances. Tests update the `EdgeCurrencyEngineCallbacks` mock by removing the stale `onSubscribeAddresses` callback to match the current type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ffd9a42ef681e2e948202222f4ff65adfa4efd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->